### PR TITLE
feat: add P0/P1 trading signal pipeline foundations

### DIFF
--- a/manekineko/__init__.py
+++ b/manekineko/__init__.py
@@ -1,0 +1,9 @@
+"""ManekiNeko trading signal research package.
+
+This package contains reusable modules for feature engineering, labeling,
+dataset construction, model training, and backtesting.
+"""
+
+__all__ = ["__version__"]
+
+__version__ = "0.1.0"

--- a/manekineko/datasets/__init__.py
+++ b/manekineko/datasets/__init__.py
@@ -1,0 +1,5 @@
+"""Dataset helpers for time-series model training."""
+
+from .window_dataset import TimeSeriesWindowDataset, WindowConfig, make_windowed_arrays
+
+__all__ = ["TimeSeriesWindowDataset", "WindowConfig", "make_windowed_arrays"]

--- a/manekineko/datasets/window_dataset.py
+++ b/manekineko/datasets/window_dataset.py
@@ -1,0 +1,151 @@
+"""Windowed datasets for time-series classifiers.
+
+Important memory rule: this module keeps tensors on CPU. Move each batch to
+GPU inside the training loop instead of moving the entire dataset to GPU.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Sequence
+
+import numpy as np
+import pandas as pd
+import torch
+from torch.utils.data import Dataset
+
+
+@dataclass(frozen=True)
+class WindowConfig:
+    """Configuration for turning a time series into supervised windows.
+
+    Attributes:
+        lookback: Number of historical rows per input sample.
+        target_offset: Offset from the window end to the target label. Use
+            ``0`` when the label at row ``t`` describes the future outcome from
+            ``t`` onward. Use ``1`` when predicting the next row's label.
+        drop_missing_labels: Drop windows whose target label is NA.
+    """
+
+    lookback: int = 240
+    target_offset: int = 0
+    drop_missing_labels: bool = True
+
+    def validate(self) -> None:
+        if self.lookback <= 0:
+            raise ValueError("lookback must be positive")
+        if self.target_offset < 0:
+            raise ValueError("target_offset must be non-negative")
+
+
+def make_windowed_arrays(
+    df: pd.DataFrame,
+    *,
+    feature_columns: Sequence[str],
+    label_column: str,
+    config: WindowConfig | None = None,
+    dtype: np.dtype = np.float32,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Create ``X, y, index`` arrays from a time-ordered DataFrame.
+
+    ``X`` has shape ``[num_samples, lookback, feature_dim]``. The target ``y``
+    is taken from ``window_end + target_offset``.
+
+    Returns:
+        ``X``: windowed features.
+        ``y``: integer labels.
+        ``target_indices``: original DataFrame row positions used as labels.
+    """
+
+    cfg = config or WindowConfig()
+    cfg.validate()
+
+    missing_features = [col for col in feature_columns if col not in df.columns]
+    if missing_features:
+        raise KeyError(f"missing feature columns: {missing_features}")
+    if label_column not in df.columns:
+        raise KeyError(f"missing label column: {label_column}")
+
+    feature_df = df.loc[:, list(feature_columns)]
+    if feature_df.isna().any().any():
+        bad_cols = feature_df.columns[feature_df.isna().any()].tolist()
+        raise ValueError(f"feature columns contain NaN values: {bad_cols}")
+
+    features = feature_df.to_numpy(dtype=dtype, copy=True)
+    labels = df[label_column].to_numpy(copy=True)
+
+    windows: list[np.ndarray] = []
+    targets: list[int] = []
+    target_indices: list[int] = []
+
+    max_window_start = len(df) - cfg.lookback - cfg.target_offset + 1
+    for start in range(max(0, max_window_start)):
+        end = start + cfg.lookback - 1
+        target_idx = end + cfg.target_offset
+        target = labels[target_idx]
+
+        if pd.isna(target):
+            if cfg.drop_missing_labels:
+                continue
+            raise ValueError(f"missing target label at row {target_idx}")
+
+        windows.append(features[start : start + cfg.lookback])
+        targets.append(int(target))
+        target_indices.append(target_idx)
+
+    if not windows:
+        feature_dim = len(feature_columns)
+        return (
+            np.empty((0, cfg.lookback, feature_dim), dtype=dtype),
+            np.empty((0,), dtype=np.int64),
+            np.empty((0,), dtype=np.int64),
+        )
+
+    return (
+        np.stack(windows).astype(dtype, copy=False),
+        np.asarray(targets, dtype=np.int64),
+        np.asarray(target_indices, dtype=np.int64),
+    )
+
+
+class TimeSeriesWindowDataset(Dataset):
+    """PyTorch Dataset for ``[lookback, feature_dim]`` windows.
+
+    The dataset stores CPU tensors only. In training code, use:
+
+    ```python
+    for x, y in loader:
+        x = x.to(device, non_blocking=True)
+        y = y.to(device, non_blocking=True)
+    ```
+    """
+
+    def __init__(
+        self,
+        X: np.ndarray | torch.Tensor,
+        y: np.ndarray | torch.Tensor,
+        *,
+        indices: np.ndarray | torch.Tensor | None = None,
+        return_index: bool = False,
+    ) -> None:
+        if len(X) != len(y):
+            raise ValueError("X and y must contain the same number of samples")
+
+        self.X = torch.as_tensor(X, dtype=torch.float32).cpu()
+        self.y = torch.as_tensor(y, dtype=torch.long).cpu()
+        self.return_index = return_index
+
+        if indices is None:
+            self.indices = torch.arange(len(self.y), dtype=torch.long)
+        else:
+            if len(indices) != len(y):
+                raise ValueError("indices and y must contain the same number of samples")
+            self.indices = torch.as_tensor(indices, dtype=torch.long).cpu()
+
+    def __len__(self) -> int:
+        return len(self.y)
+
+    def __getitem__(self, idx: int):
+        if self.return_index:
+            return self.X[idx], self.y[idx], self.indices[idx]
+        return self.X[idx], self.y[idx]

--- a/manekineko/labeling/__init__.py
+++ b/manekineko/labeling/__init__.py
@@ -1,0 +1,12 @@
+"""Label generation utilities for trading signal experiments."""
+
+from .triple_barrier import TripleBarrierConfig, apply_triple_barrier, triple_barrier_labels
+from .zone_expansion import expand_buy_sell_zones, expand_indices_to_zones
+
+__all__ = [
+    "TripleBarrierConfig",
+    "apply_triple_barrier",
+    "triple_barrier_labels",
+    "expand_buy_sell_zones",
+    "expand_indices_to_zones",
+]

--- a/manekineko/labeling/triple_barrier.py
+++ b/manekineko/labeling/triple_barrier.py
@@ -1,0 +1,217 @@
+"""Triple-barrier style labels for long-only trading experiments.
+
+The functions in this module deliberately generate labels from future market
+outcomes. That is expected in supervised learning. The important rule is that
+these labels must be used only as targets, never as model input features.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+import numpy as np
+import pandas as pd
+
+TieBreak = Literal["loss", "profit"]
+
+
+@dataclass(frozen=True)
+class TripleBarrierConfig:
+    """Configuration for triple-barrier label generation.
+
+    Attributes:
+        horizon: Maximum number of future bars to inspect.
+        profit_barrier: Net return threshold for a positive event. Example:
+            ``0.012`` means +1.2% after round-trip costs.
+        loss_barrier: Net return threshold for a negative event. Example:
+            ``-0.006`` means -0.6% after round-trip costs.
+        fee_rate_round_trip: Estimated buy+sell fee rate.
+        slippage_round_trip: Estimated buy+sell slippage rate.
+        hold_label: Label for no trade / timeout.
+        positive_label: Label when the profit barrier is hit first.
+        negative_label: Label when the loss barrier is hit first.
+        tie_break: Conservative default is ``"loss"`` when profit and loss
+            barriers are both touched inside the same candle.
+        require_full_horizon: When true, the last ``horizon`` rows are marked
+            as missing because there is not enough future data.
+    """
+
+    horizon: int = 48
+    profit_barrier: float = 0.012
+    loss_barrier: float = -0.006
+    fee_rate_round_trip: float = 0.002
+    slippage_round_trip: float = 0.001
+    hold_label: int = 1
+    positive_label: int = 2
+    negative_label: int = 3
+    tie_break: TieBreak = "loss"
+    require_full_horizon: bool = True
+
+    @property
+    def round_trip_cost(self) -> float:
+        return self.fee_rate_round_trip + self.slippage_round_trip
+
+    def validate(self) -> None:
+        if self.horizon <= 0:
+            raise ValueError("horizon must be positive")
+        if self.profit_barrier <= 0:
+            raise ValueError("profit_barrier must be positive")
+        if self.loss_barrier >= 0:
+            raise ValueError("loss_barrier must be negative")
+        if self.round_trip_cost < 0:
+            raise ValueError("round-trip cost must be non-negative")
+        if self.tie_break not in {"loss", "profit"}:
+            raise ValueError("tie_break must be either 'loss' or 'profit'")
+
+
+def _as_float_array(values: pd.Series | np.ndarray, name: str) -> np.ndarray:
+    arr = np.asarray(values, dtype=np.float64)
+    if arr.ndim != 1:
+        raise ValueError(f"{name} must be one-dimensional")
+    if np.any(~np.isfinite(arr)):
+        raise ValueError(f"{name} contains NaN or infinite values")
+    return arr
+
+
+def triple_barrier_labels(
+    close: pd.Series | np.ndarray,
+    high: pd.Series | np.ndarray | None = None,
+    low: pd.Series | np.ndarray | None = None,
+    *,
+    config: TripleBarrierConfig | None = None,
+) -> pd.DataFrame:
+    """Generate long-only triple-barrier labels.
+
+    For each row ``t``, the function simulates entering at ``close[t]`` and
+    scans the next ``horizon`` bars. The first touched barrier determines the
+    target label:
+
+    - profit barrier first -> ``positive_label``
+    - loss barrier first -> ``negative_label``
+    - neither barrier -> ``hold_label``
+
+    Returns a DataFrame with:
+
+    - ``tb_label``: nullable integer class label
+    - ``tb_event``: ``profit``, ``loss``, ``timeout``, or ``incomplete``
+    - ``tb_hit_offset``: bars until the event, nullable
+    - ``tb_net_return``: event or timeout net return after round-trip cost
+    """
+
+    cfg = config or TripleBarrierConfig()
+    cfg.validate()
+
+    close_arr = _as_float_array(close, "close")
+    high_arr = _as_float_array(high if high is not None else close_arr, "high")
+    low_arr = _as_float_array(low if low is not None else close_arr, "low")
+
+    if not (len(close_arr) == len(high_arr) == len(low_arr)):
+        raise ValueError("close, high, and low must have the same length")
+
+    n = len(close_arr)
+    labels: list[int | pd._libs.missing.NAType] = [cfg.hold_label] * n
+    events = np.full(n, "timeout", dtype=object)
+    hit_offsets: list[int | pd._libs.missing.NAType] = [pd.NA] * n
+    net_returns = np.full(n, np.nan, dtype=np.float64)
+
+    for idx in range(n):
+        if cfg.require_full_horizon and idx + cfg.horizon >= n:
+            labels[idx] = pd.NA
+            events[idx] = "incomplete"
+            continue
+
+        end = min(n - 1, idx + cfg.horizon)
+        if end <= idx:
+            labels[idx] = pd.NA
+            events[idx] = "incomplete"
+            continue
+
+        entry = close_arr[idx]
+        if entry <= 0:
+            raise ValueError("close prices must be positive")
+
+        resolved = False
+        for future_idx in range(idx + 1, end + 1):
+            high_ret = high_arr[future_idx] / entry - 1.0 - cfg.round_trip_cost
+            low_ret = low_arr[future_idx] / entry - 1.0 - cfg.round_trip_cost
+
+            hit_profit = high_ret >= cfg.profit_barrier
+            hit_loss = low_ret <= cfg.loss_barrier
+
+            if hit_profit and hit_loss:
+                if cfg.tie_break == "loss":
+                    labels[idx] = cfg.negative_label
+                    events[idx] = "loss"
+                    net_returns[idx] = low_ret
+                else:
+                    labels[idx] = cfg.positive_label
+                    events[idx] = "profit"
+                    net_returns[idx] = high_ret
+                hit_offsets[idx] = future_idx - idx
+                resolved = True
+                break
+
+            if hit_profit:
+                labels[idx] = cfg.positive_label
+                events[idx] = "profit"
+                hit_offsets[idx] = future_idx - idx
+                net_returns[idx] = high_ret
+                resolved = True
+                break
+
+            if hit_loss:
+                labels[idx] = cfg.negative_label
+                events[idx] = "loss"
+                hit_offsets[idx] = future_idx - idx
+                net_returns[idx] = low_ret
+                resolved = True
+                break
+
+        if not resolved:
+            labels[idx] = cfg.hold_label
+            events[idx] = "timeout"
+            hit_offsets[idx] = end - idx
+            net_returns[idx] = close_arr[end] / entry - 1.0 - cfg.round_trip_cost
+
+    return pd.DataFrame(
+        {
+            "tb_label": pd.Series(labels, dtype="Int64"),
+            "tb_event": events,
+            "tb_hit_offset": pd.Series(hit_offsets, dtype="Int64"),
+            "tb_net_return": net_returns,
+        }
+    )
+
+
+def apply_triple_barrier(
+    df: pd.DataFrame,
+    *,
+    close_col: str = "close",
+    high_col: str = "high",
+    low_col: str = "low",
+    config: TripleBarrierConfig | None = None,
+    prefix: str = "tb",
+) -> pd.DataFrame:
+    """Return a copy of ``df`` with triple-barrier columns appended."""
+
+    missing = [col for col in (close_col, high_col, low_col) if col not in df.columns]
+    if missing:
+        raise KeyError(f"missing required columns: {missing}")
+
+    labels = triple_barrier_labels(
+        close=df[close_col],
+        high=df[high_col],
+        low=df[low_col],
+        config=config,
+    )
+
+    out = df.copy()
+    rename_map = {
+        "tb_label": f"{prefix}_label",
+        "tb_event": f"{prefix}_event",
+        "tb_hit_offset": f"{prefix}_hit_offset",
+        "tb_net_return": f"{prefix}_net_return",
+    }
+    labels = labels.rename(columns=rename_map)
+    return pd.concat([out.reset_index(drop=True), labels], axis=1)

--- a/manekineko/labeling/zone_expansion.py
+++ b/manekineko/labeling/zone_expansion.py
@@ -1,0 +1,154 @@
+"""Utilities for converting sparse buy/sell points into tradable zones."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+
+import numpy as np
+import pandas as pd
+
+
+@dataclass(frozen=True)
+class ZoneLabels:
+    """Default label values used by the current ManekiNeko signal design."""
+
+    hold: int = 1
+    buy_zone: int = 2
+    sell_zone: int = 3
+    strong_buy: int = 4
+    strong_sell: int = 6
+
+
+def _clean_indices(indices: Iterable[int], length: int) -> list[int]:
+    clean: list[int] = []
+    for raw_idx in indices:
+        idx = int(raw_idx)
+        if 0 <= idx < length:
+            clean.append(idx)
+    return sorted(set(clean))
+
+
+def expand_indices_to_zones(
+    length: int,
+    indices: Iterable[int],
+    *,
+    zone_label: int,
+    strong_label: int | None = None,
+    pre: int = 12,
+    post: int = 2,
+    base_label: int = 1,
+) -> pd.Series:
+    """Expand sparse event indices into a continuous zone label series.
+
+    Args:
+        length: Number of rows in the target time series.
+        indices: Sparse event positions, such as primary local minima.
+        zone_label: Label applied to rows around each event.
+        strong_label: Optional label applied to the exact event index.
+        pre: Number of bars before each event to include in the zone.
+        post: Number of bars after each event to include in the zone.
+        base_label: Label used outside all zones.
+
+    Returns:
+        A pandas Series of nullable integer labels.
+    """
+
+    if length < 0:
+        raise ValueError("length must be non-negative")
+    if pre < 0 or post < 0:
+        raise ValueError("pre and post must be non-negative")
+
+    labels = np.full(length, base_label, dtype=np.int64)
+
+    for idx in _clean_indices(indices, length):
+        start = max(0, idx - pre)
+        end = min(length, idx + post + 1)
+        labels[start:end] = zone_label
+        if strong_label is not None:
+            labels[idx] = strong_label
+
+    return pd.Series(labels, dtype="Int64")
+
+
+def expand_buy_sell_zones(
+    length: int,
+    buy_indices: Iterable[int],
+    sell_indices: Iterable[int] | None = None,
+    *,
+    buy_pre: int = 12,
+    buy_post: int = 2,
+    sell_pre: int = 12,
+    sell_post: int = 2,
+    labels: ZoneLabels = ZoneLabels(),
+) -> pd.Series:
+    """Create a 1/2/3/4/6 zone label series from sparse buy/sell points.
+
+    The function uses a priority mask so strong labels are not overwritten by
+    weak zone labels. If buy and sell zones overlap, the later assignment can
+    overwrite only labels with equal or lower priority. Strong buy/sell points
+    always have the highest priority.
+    """
+
+    if length < 0:
+        raise ValueError("length must be non-negative")
+
+    out = np.full(length, labels.hold, dtype=np.int64)
+    priority = np.zeros(length, dtype=np.int64)
+
+    def assign(start: int, end: int, label: int, label_priority: int) -> None:
+        mask = priority[start:end] <= label_priority
+        segment = out[start:end]
+        segment[mask] = label
+        out[start:end] = segment
+        priority_segment = priority[start:end]
+        priority_segment[mask] = label_priority
+        priority[start:end] = priority_segment
+
+    for idx in _clean_indices(buy_indices, length):
+        assign(max(0, idx - buy_pre), min(length, idx + buy_post + 1), labels.buy_zone, 10)
+        assign(idx, idx + 1, labels.strong_buy, 100)
+
+    if sell_indices is not None:
+        for idx in _clean_indices(sell_indices, length):
+            assign(max(0, idx - sell_pre), min(length, idx + sell_post + 1), labels.sell_zone, 10)
+            assign(idx, idx + 1, labels.strong_sell, 100)
+
+    return pd.Series(out, dtype="Int64")
+
+
+def expand_existing_signal(
+    signal: pd.Series | np.ndarray,
+    *,
+    labels: ZoneLabels = ZoneLabels(),
+    buy_pre: int = 12,
+    buy_post: int = 2,
+    sell_pre: int = 12,
+    sell_post: int = 2,
+) -> pd.Series:
+    """Expand existing strong buy/sell labels into surrounding zones.
+
+    This is useful for migrating the old extrema-point labels into a zone-based
+    target without changing the extrema detector immediately.
+    """
+
+    arr = np.asarray(signal)
+    buy_indices = np.flatnonzero(arr == labels.strong_buy)
+    sell_indices = np.flatnonzero(arr == labels.strong_sell)
+
+    expanded = expand_buy_sell_zones(
+        len(arr),
+        buy_indices=buy_indices,
+        sell_indices=sell_indices,
+        buy_pre=buy_pre,
+        buy_post=buy_post,
+        sell_pre=sell_pre,
+        sell_post=sell_post,
+        labels=labels,
+    )
+
+    # Preserve existing weak labels where no expanded zone exists.
+    original = pd.Series(arr, dtype="Int64")
+    mask = expanded == labels.hold
+    expanded.loc[mask] = original.loc[mask].fillna(labels.hold)
+    return expanded.astype("Int64")

--- a/manekineko/scripts/__init__.py
+++ b/manekineko/scripts/__init__.py
@@ -1,0 +1,1 @@
+"""Command-line helpers for ManekiNeko experiments."""

--- a/manekineko/scripts/inspect_labels.py
+++ b/manekineko/scripts/inspect_labels.py
@@ -1,0 +1,107 @@
+"""Inspect label distributions for old or new ManekiNeko targets.
+
+Examples:
+    python -m manekineko.scripts.inspect_labels \
+        --csv xGboost/all-coin.csv \
+        --label signal \
+        --by tag
+
+    python -m manekineko.scripts.inspect_labels \
+        --csv data/features.csv \
+        --apply-triple-barrier \
+        --horizon 48 \
+        --profit-barrier 0.012 \
+        --loss-barrier -0.006
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import pandas as pd
+
+from manekineko.labeling import TripleBarrierConfig, apply_triple_barrier
+
+
+def _print_distribution(df: pd.DataFrame, label_col: str, by: str | None = None) -> None:
+    if label_col not in df.columns:
+        raise KeyError(f"label column not found: {label_col}")
+
+    counts = df[label_col].value_counts(dropna=False).sort_index()
+    ratio = df[label_col].value_counts(dropna=False, normalize=True).sort_index()
+
+    summary = pd.DataFrame({"count": counts, "ratio": ratio})
+    print("\nOverall label distribution")
+    print(summary.to_string())
+
+    if by:
+        if by not in df.columns:
+            raise KeyError(f"group column not found: {by}")
+        grouped = (
+            df.groupby(by, dropna=False)[label_col]
+            .value_counts(dropna=False, normalize=True)
+            .rename("ratio")
+            .reset_index()
+            .sort_values([by, label_col])
+        )
+        print(f"\nLabel ratio grouped by {by}")
+        print(grouped.to_string(index=False))
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--csv", required=True, type=Path, help="Input feature CSV path")
+    parser.add_argument("--label", default="signal", help="Existing label column to inspect")
+    parser.add_argument("--by", default=None, help="Optional grouping column, e.g. tag or symbol")
+
+    parser.add_argument(
+        "--apply-triple-barrier",
+        action="store_true",
+        help="Generate triple-barrier labels before inspection",
+    )
+    parser.add_argument("--close-col", default="close")
+    parser.add_argument("--high-col", default="high")
+    parser.add_argument("--low-col", default="low")
+    parser.add_argument("--horizon", type=int, default=48)
+    parser.add_argument("--profit-barrier", type=float, default=0.012)
+    parser.add_argument("--loss-barrier", type=float, default=-0.006)
+    parser.add_argument("--fee-round-trip", type=float, default=0.002)
+    parser.add_argument("--slippage-round-trip", type=float, default=0.001)
+    parser.add_argument("--output-csv", type=Path, default=None, help="Optional path to save labels")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    df = pd.read_csv(args.csv)
+
+    label_col = args.label
+    if args.apply_triple_barrier:
+        cfg = TripleBarrierConfig(
+            horizon=args.horizon,
+            profit_barrier=args.profit_barrier,
+            loss_barrier=args.loss_barrier,
+            fee_rate_round_trip=args.fee_round_trip,
+            slippage_round_trip=args.slippage_round_trip,
+        )
+        df = apply_triple_barrier(
+            df,
+            close_col=args.close_col,
+            high_col=args.high_col,
+            low_col=args.low_col,
+            config=cfg,
+            prefix="tb",
+        )
+        label_col = "tb_label"
+
+    _print_distribution(df, label_col=label_col, by=args.by)
+
+    if args.output_csv:
+        args.output_csv.parent.mkdir(parents=True, exist_ok=True)
+        df.to_csv(args.output_csv, index=False)
+        print(f"\nSaved output to {args.output_csv}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

This PR starts the implementation of the PRD trading signal pipeline foundations.

## Added

- `manekineko/labeling/triple_barrier.py`
  - Long-only triple-barrier style labels
  - Fee/slippage-aware net return labeling
  - Incomplete tail rows marked as nullable labels

- `manekineko/labeling/zone_expansion.py`
  - Converts sparse buy/sell points into continuous buy/sell zones
  - Preserves the existing 1/2/3/4/6 signal semantics

- `manekineko/datasets/window_dataset.py`
  - Builds `[num_samples, lookback, feature_dim]` arrays
  - Keeps tensors on CPU to avoid loading the whole dataset into GPU memory
  - Supports target offset and missing label dropping

- `manekineko/scripts/inspect_labels.py`
  - CLI helper for checking old or new label distributions
  - Can optionally generate triple-barrier labels from a CSV

## Design notes

- Labels may use future market outcomes, but must be used only as `y`, never as model input features.
- Dataset tensors intentionally stay on CPU. Training code should move each batch to GPU inside the loop.
- This PR does not modify existing notebooks or current training scripts.

## Example

```bash
python -m manekineko.scripts.inspect_labels \
  --csv xGboost/all-coin.csv \
  --label signal \
  --by tag

python -m manekineko.scripts.inspect_labels \
  --csv data/features.csv \
  --apply-triple-barrier \
  --horizon 48 \
  --profit-barrier 0.012 \
  --loss-barrier -0.006
```

## Next PR

- Add feature column selection / leakage guard
- Add train/validation/test time split with purge/embargo
- Add baseline LightGBM/XGBoost training entrypoint
- Add fee-aware event backtester